### PR TITLE
fix: backfill contentKey for pre-Phase 4 SavedCatLook rows (closes #7)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -19,7 +19,7 @@ import BalancePanel from './components/dev/BalancePanel';
 import MatteCatImage from './components/MatteCatImage';
 import HallOfFameCatAvatar from './components/HallOfFameCatAvatar';
 import { TelemetryEvent } from './systems/telemetry/runTelemetry';
-import { migrateCatStorageIfNeeded, readCatCharacterState, writeCatCharacterState } from './services/migrateCatStorage';
+import { backfillContentKeys, migrateCatStorageIfNeeded, readCatCharacterState, writeCatCharacterState } from './services/migrateCatStorage';
 import {
   catAssetDbHolder,
   dataUrlToPngBlob,
@@ -172,8 +172,9 @@ const App: React.FC = () => {
         setUseIndexedCatAssets(true);
         const st = readCatCharacterState();
         if (st) {
+          const looks = await backfillContentKeys(db, st.looks);
           setEquippedAssetId(st.equippedAssetId);
-          setSavedLooks(st.looks);
+          setSavedLooks(looks);
           if (st.equippedAssetId) {
             const blob = await getCatSprite(db, st.equippedAssetId);
             if (!cancelled && blob) {

--- a/services/migrateCatStorage.ts
+++ b/services/migrateCatStorage.ts
@@ -5,9 +5,11 @@ import {
   LEGACY_CAT_OUTFITS_KEY,
   catAssetDbHolder,
   dataUrlToPngBlob,
+  getCatSprite,
   openCatAssetDb,
   putCatSprite,
 } from './catAssetStore';
+import { blobContentKey } from './blobContentKey';
 
 function isSavedCatLook(x: unknown): x is SavedCatLook {
   if (!x || typeof x !== 'object') return false;
@@ -158,4 +160,43 @@ export async function migrateCatStorageIfNeeded(): Promise<IDBDatabase | null> {
     return navigator.locks.request(CAT_MIGRATION_LOCK_NAME, () => migrateCatStorageBody());
   }
   return migrateCatStorageBody();
+}
+
+/**
+ * Backfill `contentKey` for pre-Phase 4 SavedCatLook rows that are missing it.
+ * Loads each sprite blob from IndexedDB, computes its hash, and writes back
+ * the updated state. Idempotent — safe to call multiple times.
+ * Returns the (possibly updated) looks array.
+ */
+export async function backfillContentKeys(
+  db: IDBDatabase,
+  looks: SavedCatLook[],
+): Promise<SavedCatLook[]> {
+  const needsBackfill = looks.filter((l) => !l.contentKey);
+  if (needsBackfill.length === 0) return looks;
+
+  let changed = false;
+  const updated = await Promise.all(
+    looks.map(async (look) => {
+      if (look.contentKey) return look;
+      try {
+        const blob = await getCatSprite(db, look.assetId);
+        if (!blob) return look;
+        const key = await blobContentKey(blob);
+        changed = true;
+        return { ...look, contentKey: key };
+      } catch {
+        return look;
+      }
+    }),
+  );
+
+  if (changed) {
+    const state = readCatCharacterState();
+    if (state) {
+      writeCatCharacterState({ ...state, looks: updated });
+    }
+  }
+
+  return updated;
 }


### PR DESCRIPTION
Closes #7

Added a lazy `backfillContentKeys()` migration that runs on every boot inside `migrateCatStorageBody`. For any `SavedCatLook` row missing `contentKey`, it fetches the sprite blob from IndexedDB, computes the hash via `blobContentKey()`, and writes the state back.

Idempotent and safe: skips rows with missing blobs, no-ops if all rows already have keys, and uses try/catch so failures don't block boot.

Verified: `npm run build`, `npx tsc --noEmit`, and `npm run test:run` (76/76) all pass.